### PR TITLE
use latest lds, fix bug with sagalog

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ./init-db-and-user.sql:/docker-entrypoint-initdb.d/init.sql
 
   lds:
-    image: statisticsnorway/lds-server:1.0.0
+    image: statisticsnorway/lds-server:latest
     ports:
       - 9090:9090
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
     volumes:
       - ./gsim-raml-schema/graphqlschemas:/graphqlschemas
     environment:
-      - JAVA_MODULE_SYSTEM_ENABLED=true
+      - JAVA_MODULE_SYSTEM_ENABLED=false
       - LDS_persistence.provider=postgres
       - LDS_postgres.driver.host=postgresdb
       - LDS_postgres.driver.port:5432

--- a/import.sh
+++ b/import.sh
@@ -14,7 +14,7 @@ fi
 for i in $(find examples -type f); do
   ENTITY=$(echo "$i" | sed 's:examples/::' | sed 's:\([^_]*\).*:\1:')
   ID=$("$jqv" -r .id "$i")
-  curl -X PUT http://localhost:9090/ns/"${ENTITY}"/"${ID}" -d "@$i" -H "Content-Type: application/json"
+  curl -X POST http://localhost:9090/ns/"${ENTITY}"/"${ID}" -d "@$i" -H "Content-Type: application/json"
 done
 
 wait

--- a/run.sh
+++ b/run.sh
@@ -8,4 +8,5 @@ if [ ! -f "gsim-raml-schema/graphqlschemas/schema.graphql" ]; then
   docker run -v "$1"/gsim-raml-schema:/raml-project statisticsnorway/raml-to-graphql-schema:latest
 fi
 
+docker pull statisticsnorway/lds-server:latest
 docker-compose up -d

--- a/run.sh
+++ b/run.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+docker-compose down
+
 if [ ! -d "gsim-raml-schema" ]; then
   git clone https://github.com/statisticsnorway/gsim-raml-schema.git
 fi


### PR DESCRIPTION
We should be supporting the latest version of LDS, because that's always the one KLASS is using.

The latest version of LDS as of now (1.0.3) has support for timelines, which we need to test and build against.

This pull request also fixes a bug where SAGALOG would be throwing errors when POSTing data to lds.